### PR TITLE
Add GitHub Actions workflow for linting with Ruff

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,33 @@
+name: Lint with Ruff
+
+on:
+  push:
+    branches: ["**"]
+    paths:
+      - "**.py"
+      - "pyproject.toml"
+      - ".ruff.toml"
+      - "lint.yml"
+  pull_request:
+    branches: [develop, main]
+
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ruff-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+      - name: Install deps (locked)
+        run: uv sync --frozen
+      - name: Ruff check
+        run: uv run ruff check .
+      - name: Ruff format --check
+        run: uv run ruff format --check .

--- a/app/config.py
+++ b/app/config.py
@@ -10,13 +10,13 @@ class Settings(BaseSettings):
     azure_openai_deployment: str = Field(alias="AZURE_OPENAI_DEPLOYMENT")
     azure_openai_api_version: str = Field(alias="AZURE_OPENAI_API_VERSION")
 
-
     model_config = SettingsConfigDict(
         env_file=".env",
         env_file_encoding="utf-8",
         case_sensitive=True,
         extra="ignore",
     )
+
 
 @lru_cache
 def get_settings() -> Settings:

--- a/app/routers/chat.py
+++ b/app/routers/chat.py
@@ -25,6 +25,4 @@ class ChatResponse(BaseModel):
 async def chat_with_agent(request: ChatRequest):
     state = {"messages": [m.model_dump() for m in request.messages]}
     result = graph.invoke(state)
-    return {
-        "messages": [convert_message(m) for m in result["messages"]]
-    }
+    return {"messages": [convert_message(m) for m in result["messages"]]}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for automated linting of Python code using Ruff. The workflow is triggered on pushes and pull requests affecting Python files or configuration files, and runs Ruff checks and formatting validation in a CI environment.

Continuous Integration improvements:

* Added `.github/workflows/lint.yml` workflow to automatically run Ruff lint and format checks on Python files and relevant configuration files for all branches and pull requests to `develop` and `main`.
* Configured the workflow to use Python 3.13, set up dependencies with `uv`, and enable caching for faster runs.
* Added concurrency controls to prevent overlapping runs for the same branch or pull request.